### PR TITLE
Update code for React 0.14.3.

### DIFF
--- a/lib/components/Menu.jsx
+++ b/lib/components/Menu.jsx
@@ -1,8 +1,5 @@
-/** @jsx React.DOM */
-
 var React = require('react');
-
-var cloneWithProps = require('react/lib/cloneWithProps');
+var ReactDOM = require('react-dom');
 var MenuTrigger = require('./MenuTrigger');
 var MenuOptions = require('./MenuOptions');
 var MenuOption = require('./MenuOption');
@@ -47,7 +44,7 @@ var Menu = module.exports = React.createClass({
   },
 
   handleBlur: function(e) {
-    var domNode = this.getDOMNode();
+    var domNode = ReactDOM.findDOMNode(this);
     
     // give next element a tick to take focus
     setTimeout(function() {
@@ -69,8 +66,8 @@ var Menu = module.exports = React.createClass({
   },
 
   updatePositioning: function() {
-    var triggerRect = this.refs.trigger.getDOMNode().getBoundingClientRect();
-    var optionsRect = this.refs.options.getDOMNode().getBoundingClientRect();
+    var triggerRect = ReactDOM.findDOMNode(this.refs.trigger).getBoundingClientRect();
+    var optionsRect = ReactDOM.findDOMNode(this.refs.options).getBoundingClientRect();
     var positionState = {};
     // horizontal = left if it wont fit on left side
     if (triggerRect.left + optionsRect.width > window.innerWidth) {
@@ -102,9 +99,10 @@ var Menu = module.exports = React.createClass({
   renderTrigger: function() {
     var trigger;
     if(this.verifyTwoChildren()) {
-      React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuTrigger.type) {
-          trigger = cloneWithProps(child, {
+      React.Children.forEach(this.props.children, function(child, index) {
+        if (child.type === MenuTrigger) {
+          trigger = React.cloneElement(child, {
+            key: child.key || index,
             ref: 'trigger',
             onToggleActive: this.handleTriggerToggle
           });
@@ -117,9 +115,10 @@ var Menu = module.exports = React.createClass({
   renderMenuOptions: function() {
     var options;
     if(this.verifyTwoChildren()) {
-      React.Children.forEach(this.props.children, function(child){
-        if (child.type === MenuOptions.type) {
-          options = cloneWithProps(child, {
+      React.Children.forEach(this.props.children, function(child, index) {
+        if (child.type === MenuOptions) {
+          options = React.cloneElement(child, {
+            key: child.key || index,
             ref: 'options',
             horizontalPlacement: this.state.horizontalPlacement,
             verticalPlacement: this.state.verticalPlacement,

--- a/lib/components/MenuOption.jsx
+++ b/lib/components/MenuOption.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 var buildClassName = require('../mixins/buildClassName');
 

--- a/lib/components/MenuOptions.jsx
+++ b/lib/components/MenuOptions.jsx
@@ -1,8 +1,6 @@
-/** @jsx React.DOM */
-
 var React = require('react');
+var ReactDOM = require('react-dom');
 var MenuOption = require('./MenuOption');
-var cloneWithProps = require('react/lib/cloneWithProps')
 var buildClassName = require('../mixins/buildClassName');
 
 var MenuOptions = module.exports = React.createClass({
@@ -57,7 +55,7 @@ var MenuOptions = module.exports = React.createClass({
   },
 
   updateFocusIndexBy: function(delta) {
-    var optionNodes = this.getDOMNode().querySelectorAll('.Menu__MenuOption');
+    var optionNodes = ReactDOM.findDOMNode(this).querySelectorAll('.Menu__MenuOption');
     this.normalizeSelectedBy(delta, optionNodes.length);
     this.setState({activeIndex: this.selectedIndex}, function () {
       optionNodes[this.selectedIndex].focus();
@@ -66,11 +64,12 @@ var MenuOptions = module.exports = React.createClass({
 
   renderOptions: function() {
     var index = 0;
-    return React.Children.map(this.props.children, function(c){
+    return React.Children.map(this.props.children, function(c, i) {
       var clonedOption = c;
-      if (c.type === MenuOption.type) {
+      if (c.type === MenuOption) {
         var active = this.state.activeIndex === index;
-        clonedOption = cloneWithProps(c, {
+        clonedOption = React.cloneElement(c, {
+          key: c.key || i,
           active: active,
           index: index,
           _internalFocus: this.focusOption,

--- a/lib/components/MenuTrigger.jsx
+++ b/lib/components/MenuTrigger.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 var buildClassName = require('../mixins/buildClassName');
 

--- a/package.json
+++ b/package.json
@@ -33,14 +33,16 @@
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.3",
     "mocha": "1.20.1",
-    "react": "^0.13.0",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
     "reactify": "^0.14.0",
     "rf-release": "0.3.1",
     "uglify-js": "2.4.15",
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {
-    "react": "^0.13.0"
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3"
   },
   "tags": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-menu",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Accessible menu component for React.JS",
   "main": "./lib/index",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-menu",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "Accessible menu component for React.JS",
   "main": "./lib/index",
   "repository": {


### PR DESCRIPTION
These changes make the react-menu compliant with React 0.14.3, and include:
* Moving to use the ReactDOM API.
* Passing down or setting `key` props for cloned components.
* Checking type by comparison to the component object instead of the `type` key.

This version should not be used until the massdrop-react repository has also been upgraded to React 0.14.3.