### PR TITLE
Ted/update show hide menu styling

### DIFF
--- a/lib/components/MenuOptions.jsx
+++ b/lib/components/MenuOptions.jsx
@@ -95,7 +95,7 @@ var MenuOptions = module.exports = React.createClass({
         role="menu"
         tabIndex="-1"
         aria-expanded={this.context.active}
-        style={{visibility: this.context.active ? 'visible' : 'hidden'}}
+        style={{display: this.context.active ? 'block' : 'none'}}
         className={this.buildName()}
         onKeyDown={this.handleKeys}
       >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-menu",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Accessible menu component for React.JS",
   "main": "./lib/index",
   "repository": {

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+git pull
+npm version patch
+PACKAGE=$(npm pack)
+echo PACKAGE: $PACKAGE
+curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/
+rm $PACKAGE
+git push


### PR DESCRIPTION
* Changed styling from `visibility: visible/hidden` to `display: none/block` as `visibility` doesn't remove hidden item from taking up space on the page.
* This will help prevent any styling issues that have arisen in the past.
* Also updated `package.json` version to reflect newest version number published earlier today.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/massdrop/react-menu/3)
<!-- Reviewable:end -->
